### PR TITLE
Sanitize volume preference handling

### DIFF
--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -91,6 +91,9 @@ class PlaylistContentNotifier extends ChangeNotifier {
   double _volume = 100.0; // 当前音量
   double _lastVolumeBeforeMute = 100.0; // 静音前的音量
 
+  static const _volumeKey = 'player_volume';
+  static const _lastVolumeBeforeMuteKey = 'player_last_volume';
+
   double get volume => _volume;
   double get lastVolumeBeforeMute => _lastVolumeBeforeMute;
 
@@ -247,21 +250,45 @@ class PlaylistContentNotifier extends ChangeNotifier {
     _albumSortOrders = await _playlistManager.loadAlbumSortOrders();
   }
 
+  double _sanitizeVolume(double? value, double fallback) {
+    if (value == null || value.isNaN || value.isInfinite) {
+      return fallback;
+    }
+    final clamped = value.clamp(0.0, 100.0);
+    return clamped.toDouble();
+  }
+
   Future<void> _loadVolumeSetting() async {
     final prefs = await SharedPreferences.getInstance();
-    _volume = prefs.getDouble('player_volume') ?? 100.0;
-    _lastVolumeBeforeMute = _volume;
+    _volume = _sanitizeVolume(prefs.getDouble(_volumeKey), 100.0);
+
+    final defaultLastVolume = _volume < 1.0 ? 100.0 : _volume;
+    final storedLastVolume =
+        _sanitizeVolume(prefs.getDouble(_lastVolumeBeforeMuteKey), defaultLastVolume);
+    _lastVolumeBeforeMute =
+        storedLastVolume < 1.0 ? defaultLastVolume : storedLastVolume;
+
     await _mediaPlayer.setVolume(_volume);
   }
 
   Future<void> setVolume(double newVolume) async {
+    if (newVolume.isNaN || newVolume.isInfinite) {
+      newVolume = 0.0;
+    }
+
     _volume = newVolume.clamp(0.0, 100.0);
     if (_volume > 1.0) _lastVolumeBeforeMute = _volume;
 
     await _mediaPlayer.setVolume(_volume);
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setDouble('player_volume', _volume);
+    final defaultLastVolume = _volume < 1.0 ? 100.0 : _volume;
+    final sanitizedLastVolume =
+        _sanitizeVolume(_lastVolumeBeforeMute, defaultLastVolume);
+    _lastVolumeBeforeMute =
+        sanitizedLastVolume < 1.0 ? defaultLastVolume : sanitizedLastVolume;
+    await prefs.setDouble(_volumeKey, _volume);
+    await prefs.setDouble(_lastVolumeBeforeMuteKey, _lastVolumeBeforeMute);
 
     notifyListeners();
   }

--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -282,11 +282,6 @@ class PlaylistContentNotifier extends ChangeNotifier {
     await _mediaPlayer.setVolume(_volume);
 
     final prefs = await SharedPreferences.getInstance();
-    final defaultLastVolume = _volume < 1.0 ? 100.0 : _volume;
-    final sanitizedLastVolume =
-        _sanitizeVolume(_lastVolumeBeforeMute, defaultLastVolume);
-    _lastVolumeBeforeMute =
-        sanitizedLastVolume < 1.0 ? defaultLastVolume : sanitizedLastVolume;
     await prefs.setDouble(_volumeKey, _volume);
     await prefs.setDouble(_lastVolumeBeforeMuteKey, _lastVolumeBeforeMute);
 

--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -272,11 +272,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
   }
 
   Future<void> setVolume(double newVolume) async {
-    if (newVolume.isNaN || newVolume.isInfinite) {
-      newVolume = 0.0;
-    }
-
-    _volume = newVolume.clamp(0.0, 100.0);
+    _volume = _sanitizeVolume(newVolume, 0.0);
     if (_volume > 1.0) _lastVolumeBeforeMute = _volume;
 
     await _mediaPlayer.setVolume(_volume);


### PR DESCRIPTION
## Summary
- sanitize stored volume values loaded from shared preferences to avoid invalid slider states
- persist cleaned last-volume values whenever the current volume changes
- centralize player volume keys to avoid typos and duplicate literals

## Testing
- not run (Flutter SDK unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_b_68e4d8c24fa483268fdd6386d35e0bd7