### PR TITLE
提升对 Linux 平台的兼容性

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,7 +47,9 @@ void main() async {
 
   // 初始化系统托盘
   await trayManager.setIcon('assets/images/icon/tray_icon.ico');
-  await trayManager.setToolTip('MyuneMusic');
+  if (!Platform.isLinux) {
+    await trayManager.setToolTip('MyuneMusic');
+  }
 
   final Menu menu = Menu(
     items: [
@@ -293,7 +295,9 @@ class _MyAppState extends State<MyApp> with TrayListener {
   @override
   void onTrayIconRightMouseDown() {
     // 右键点击托盘图标时弹出菜单
-    trayManager.popUpContextMenu();
+    if (!Platform.isLinux) {
+      trayManager.popUpContextMenu();
+    }
   }
 
   @override


### PR DESCRIPTION
tray_manager 在 Linux 上没[^1]这两个方法，可能会导致应用程序无法正常运行
<details>
<img width="1366" height="739" alt="image" src="https://github.com/user-attachments/assets/02b8b5b8-a57f-4261-b514-f448d0c97edb" />
</details>
已在 Arch Linux + Sway（Wayland） 上测试
<details>
Wayland:  
<img width="1366" height="737" alt="image" src="https://github.com/user-attachments/assets/2be63dca-74c9-4ef3-b502-d987c9f08192" />
XWayland:  
<img width="1366" height="738" alt="image" src="https://github.com/user-attachments/assets/c141b9ca-b781-4379-ac46-65abf882dbbb" />
</details>

[^1]: https://github.com/leanflutter/tray_manager/blob/main/README.md#traymanager