### PR TITLE
Add metadata cache and lazy cover loading

### DIFF
--- a/lib/page/playlist/playlist_content_widget.dart
+++ b/lib/page/playlist/playlist_content_widget.dart
@@ -1118,6 +1118,46 @@ class SongTileWidget extends StatefulWidget {
 
 class _SongTileWidgetState extends State<SongTileWidget> {
   bool _isHovered = false;
+  String? _requestedCoverPath;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _requestCover(widget.song.filePath);
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant SongTileWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.song.filePath != widget.song.filePath) {
+      _releaseCover(oldWidget.song.filePath);
+      _requestCover(widget.song.filePath);
+    }
+  }
+
+  @override
+  void dispose() {
+    _releaseCover(widget.song.filePath);
+    super.dispose();
+  }
+
+  void _requestCover(String filePath) {
+    _requestedCoverPath = filePath;
+    context.read<PlaylistContentNotifier>().requestSongCover(filePath);
+  }
+
+  void _releaseCover(String filePath) {
+    if (_requestedCoverPath == null) {
+      return;
+    }
+    context.read<PlaylistContentNotifier>().releaseSongCover(filePath);
+    _requestedCoverPath = null;
+  }
 
   void _showSongContextMenu(
     Offset position,

--- a/lib/page/playlist/playlist_manager.dart
+++ b/lib/page/playlist/playlist_manager.dart
@@ -12,6 +12,7 @@ class PlaylistManager {
   static const String _allSongsOrderFileName = 'all_songs_order.json';
   static const String _artistSortOrderFileName = 'artist_sort_order.json';
   static const String _albumSortOrderFileName = 'album_sort_order.json';
+  static const String _songMetadataCacheFileName = 'song_metadata_cache.json';
   static const String _migrationFlagKey = 'data_migrated_to_app_support';
 
   Future<String> _getLocalPath() async {
@@ -247,6 +248,11 @@ class PlaylistManager {
   Future<File> _getAllSongsOrderFile() async {
     final path = await _getLocalPath();
     return File('$path/$_allSongsOrderFileName');
+  }
+
+  Future<File> getSongMetadataCacheFile() async {
+    final path = await _getLocalPath();
+    return File('$path/$_songMetadataCacheFileName');
   }
 
   // 加载全部歌曲的顺序（一个文件路径列表）

--- a/lib/page/playlist/playlist_models.dart
+++ b/lib/page/playlist/playlist_models.dart
@@ -31,6 +31,42 @@ class Song {
   }
 }
 
+class SongMetadataCacheEntry {
+  final String title;
+  final String artist;
+  final String album;
+  final int? durationMs;
+  final int modifiedMs;
+
+  const SongMetadataCacheEntry({
+    required this.title,
+    required this.artist,
+    required this.album,
+    required this.modifiedMs,
+    this.durationMs,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'artist': artist,
+      'album': album,
+      'durationMs': durationMs,
+      'modifiedMs': modifiedMs,
+    };
+  }
+
+  factory SongMetadataCacheEntry.fromJson(Map<String, dynamic> json) {
+    return SongMetadataCacheEntry(
+      title: json['title'] ?? '',
+      artist: json['artist'] ?? '',
+      album: json['album'] ?? '',
+      durationMs: json['durationMs'],
+      modifiedMs: json['modifiedMs'] ?? 0,
+    );
+  }
+}
+
 class Playlist {
   final String id;
   String name;


### PR DESCRIPTION
### Motivation

- Reduce expensive startup scanning by persisting textual audio metadata and verifying files lazily to make UI show lists instantly.
- Avoid loading cover images at startup and instead load them on viewport demand to minimize random disk reads on mechanical drives.
- Keep memory usage bounded by only retaining visible cover bitmaps and keeping textual metadata resident.

### Description

- Added a cache model `SongMetadataCacheEntry` and a cache file location (`_songMetadataCacheFileName` + `getSongMetadataCacheFile`) in `PlaylistManager` to persist parsed metadata to `song_metadata_cache.json`.
- Load the metadata cache on startup via `_loadSongMetadataCache`, reuse cached entries in `_parseSongMetadata`, debounce saves with `_scheduleMetadataCacheSave`, and prune stale entries with `_pruneMetadataCache` in `playlist_content_notifier.dart`.
- Implemented background verification `_verifySongMetadataInBackground` that checks `File.stat().modified` and only re-reads metadata via `readAudioInfo` when a file changed, updating in-memory `Song` objects with `_applyCachedMetadata`.
- Implemented viewport-driven cover loading with `_visibleCoverPaths`, `_coverQueue`, `_coverWorker` and request/release APIs (`requestSongCover`/`releaseSongCover`), and updated `SongTileWidget` to request and release covers in `initState`/`didUpdateWidget`/`dispose` so covers are loaded on demand and evicted when offscreen.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724ffe071883309b2be2570a4a6b1e)