### PR TITLE
fix(song_detail_page): 修复 MeshGradient 背景动画跳跃问题

### DIFF
--- a/lib/page/song_detail_page.dart
+++ b/lib/page/song_detail_page.dart
@@ -155,7 +155,7 @@ class _BackgroundBlurWidgetState extends State<BackgroundBlurWidget>
   void _manageAnimation(bool shouldAnimate) {
     if (shouldAnimate) {
       if (!_animationController.isAnimating) {
-        _animationController.repeat();
+        _animationController.repeat(reverse: true);// 重复播放，反向播放
       }
     } else {
       if (_animationController.isAnimating) {


### PR DESCRIPTION
### 问题
在歌曲详情页中，动态背景的动画播放完成后会突然跳回起始状态，导致视觉上的跳跃感，影响用户体验。
`_animationController.repeat() `默认从 0.0 → 1.0 循环播放没有平滑过渡。