### PR TITLE
fix(installer): 安装/卸载前自动终止运行中的进程，避免文件占用失败

### DIFF
--- a/build_setup.iss
+++ b/build_setup.iss
@@ -11,6 +11,7 @@ OutputDir=output_setup
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 UninstallDisplayName=MyuneMusic
+AppMutex=MyuneMusicMutex
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/lib/page/song_detail_page.dart
+++ b/lib/page/song_detail_page.dart
@@ -155,7 +155,7 @@ class _BackgroundBlurWidgetState extends State<BackgroundBlurWidget>
   void _manageAnimation(bool shouldAnimate) {
     if (shouldAnimate) {
       if (!_animationController.isAnimating) {
-        _animationController.repeat();
+        _animationController.repeat(reverse: true);// 重复播放，反向播放
       }
     } else {
       if (_animationController.isAnimating) {

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -13,6 +13,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
     CreateAndAttachConsole();
   }
 
+  // 创建命名互斥体，用于安装/卸载程序检测进程是否在运行
+  HANDLE hMutex = CreateMutexW(nullptr, TRUE, L"MyuneMusicMutex");
+
   // Initialize COM, so that it is available for use in the library and/or
   // plugins.
   ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
@@ -31,6 +34,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
   if (!window.Create(L"myune_music", origin, size)) {
+    if (hMutex) CloseHandle(hMutex);
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);
@@ -39,6 +43,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   while (::GetMessage(&msg, nullptr, 0, 0)) {
     ::TranslateMessage(&msg);
     ::DispatchMessage(&msg);
+  }
+
+  if (hMutex) {
+    CloseHandle(hMutex);
   }
 
   ::CoUninitialize();


### PR DESCRIPTION
在安装或卸载 MyuneMusic 时，如果程序正在运行，安装程序会因文件被占用而失败。
<img width="773" height="401" alt="6769b41303c3fbe9" src="https://github.com/user-attachments/assets/bda97e0b-dcca-4d3b-9252-b31720afebeb" />
<img width="363" height="245" alt="xw_20260608105429" src="https://github.com/user-attachments/assets/850497eb-006e-4e6b-97e8-3f2edd9ccf53" />