### PR TITLE
改进"歌单扫描"功能 — 支持文件夹歌单选择扫描、支持普通歌单选择清理

### DIFF
--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -1301,7 +1301,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
 
       // 更新当前播放列表和所有歌曲列表
       if (_selectedIndex == _playlists.indexOf(currentPlaylist)) {
-        _currentPlaylistSongs = List.from(currentPlaylist.songs ?? []);
+        _currentPlaylistSongs = currentPlaylist.songs ?? [];
       }
       await _updateAllSongsList();
 
@@ -1443,7 +1443,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
 
       // 如果当前选中的就是这个播放列表，则更新当前播放列表歌曲
       if (_selectedIndex == _playlists.indexOf(playlist)) {
-        _currentPlaylistSongs = List.from(playlist.songs ?? []);
+        _currentPlaylistSongs = playlist.songs ?? [];
       }
 
       // 更新所有歌曲列表
@@ -1463,6 +1463,84 @@ class PlaylistContentNotifier extends ChangeNotifier {
       _isLoadingSongs = false;
       notifyListeners();
     }
+  }
+
+  /// 通过歌单ID刷新指定的文件夹歌单，返回新增和移除的文件路径
+  Future<({List<String> added, List<String> removed})>
+      refreshFolderPlaylistById(String playlistId) async {
+    final index = _playlists.indexWhere((p) => p.id == playlistId);
+    if (index < 0) return (added: <String>[], removed: <String>[]);
+
+    final playlist = _playlists[index];
+    if (!playlist.isFolderBased) return (added: <String>[], removed: <String>[]);
+
+    final Set<String> songPaths = <String>{};
+
+    for (final folderPath in playlist.folderPaths) {
+      try {
+        final directory = Directory(folderPath);
+        if (await directory.exists()) {
+          await for (final file in directory.list(
+            recursive: true,
+            followLinks: false,
+          ).handleError((_) {})) {
+            if (file is File) {
+              final extension = p.extension(file.path).toLowerCase();
+              if (_supportedAudioExtensions.contains(extension)) {
+                songPaths.add(p.normalize(file.path));
+              }
+            }
+          }
+        }
+      } catch (e) {
+        debugPrint('扫描目录失败: $folderPath, $e');
+      }
+    }
+
+    final oldSongPaths =
+        playlist.songFilePaths.map((fp) => p.normalize(fp).toLowerCase()).toSet();
+    final newSongPaths =
+        songPaths.map((fp) => fp.toLowerCase()).toSet();
+
+    final addedSongPaths = newSongPaths.difference(oldSongPaths).toList();
+    final removedSongPaths = oldSongPaths.difference(newSongPaths);
+
+    playlist.songFilePaths.removeWhere(
+      (path) => removedSongPaths.contains(p.normalize(path).toLowerCase()),
+    );
+
+    // addedSongPaths 是小写差集，需从原始 songPaths 中找回实际路径
+    final actualAddedPaths = songPaths
+        .where((fp) => addedSongPaths.contains(fp.toLowerCase()))
+        .toList();
+    playlist.songFilePaths.addAll(actualAddedPaths);
+
+    if (playlist.songs != null) {
+      playlist.songs!.removeWhere(
+        (song) => removedSongPaths.contains(p.normalize(song.filePath).toLowerCase()),
+      );
+
+      final parsedSongs = await Future.wait(
+        actualAddedPaths.map((path) => _parseSongMetadata(path)),
+      );
+      playlist.songs!.addAll(parsedSongs);
+    } else {
+      final parsedSongs = await Future.wait(
+        playlist.songFilePaths.map((path) => _parseSongMetadata(path)),
+      );
+      playlist.songs = parsedSongs.toList();
+    }
+
+    await _savePlaylists();
+
+    if (_selectedIndex == index) {
+      _currentPlaylistSongs = playlist.songs ?? [];
+    }
+
+    await _updateAllSongsList();
+    notifyListeners();
+
+    return (added: actualAddedPaths, removed: removedSongPaths.toList());
   }
 
   // 更新播放列表的文件夹路径
@@ -1682,12 +1760,14 @@ class PlaylistContentNotifier extends ChangeNotifier {
   }
 
   // 查找歌单中不存在的文件
-  Future<Map<String, List<String>>> findInvalidFiles() async {
-    final Map<String, List<String>> invalidFiles = {};
+  // [playlistIds] 为空时扫描所有歌单
+  // 返回 Map<歌单ID, MapEntry<歌单名, 无效文件路径列表>>
+  Future<Map<String, MapEntry<String, List<String>>>> findInvalidFiles({List<String>? playlistIds}) async {
+    final Map<String, MapEntry<String, List<String>>> invalidFiles = {};
+    final targetIds = playlistIds?.toSet();
 
     for (final playlist in _playlists) {
-      // 跳过基于文件夹的歌单
-      if (playlist.isFolderBased) continue;
+      if (targetIds != null && !targetIds.contains(playlist.id)) continue;
 
       final invalidPaths = <String>[];
 
@@ -1699,38 +1779,73 @@ class PlaylistContentNotifier extends ChangeNotifier {
       }
 
       if (invalidPaths.isNotEmpty) {
-        invalidFiles[playlist.name] = invalidPaths;
+        invalidFiles[playlist.id] = MapEntry(playlist.name, invalidPaths);
       }
     }
 
     return invalidFiles;
   }
 
-  // 清理歌单中不存在的文件
-  Future<int> cleanInvalidFiles() async {
+  // 清理歌单中指定的文件路径
+  // [filesToRemove] key为歌单ID，value为要删除的文件路径集合
+  Future<int> cleanInvalidFiles({Map<String, Set<String>>? filesToRemove}) async {
     int totalRemoved = 0;
+    final affectedIndices = <int>{};
 
-    for (final playlist in _playlists) {
-      // 跳过基于文件夹的歌单
-      if (playlist.isFolderBased) continue;
+    for (int i = 0; i < _playlists.length; i++) {
+      final playlist = _playlists[i];
 
+      final targetSet = filesToRemove?[playlist.id];
       final originalLength = playlist.songFilePaths.length;
-      final updatedPaths = <String>[];
-      for (final path in playlist.songFilePaths) {
-        final file = File(path);
-        if (await file.exists()) {
-          updatedPaths.add(path);
-        }
-      }
-      playlist.songFilePaths = updatedPaths;
 
-      totalRemoved += originalLength - playlist.songFilePaths.length;
+      Set<String> removedNormalized;
+      if (targetSet != null && targetSet.isNotEmpty) {
+        // 移除指定的文件路径
+        removedNormalized = targetSet.map((fp) => p.normalize(fp).toLowerCase()).toSet();
+        playlist.songFilePaths = playlist.songFilePaths.where((path) {
+          return !removedNormalized.contains(p.normalize(path).toLowerCase());
+        }).toList();
+      } else if (filesToRemove == null) {
+        // 未提供过滤条件时，移除所有不存在的文件（兼容旧行为）
+        final updatedPaths = <String>[];
+        final removedPaths = <String>[];
+        for (final path in playlist.songFilePaths) {
+          final file = File(path);
+          if (await file.exists()) {
+            updatedPaths.add(path);
+          } else {
+            removedPaths.add(path);
+          }
+        }
+        playlist.songFilePaths = updatedPaths;
+        removedNormalized = removedPaths.map((fp) => p.normalize(fp).toLowerCase()).toSet();
+      } else {
+        continue;
+      }
+
+      final removed = originalLength - playlist.songFilePaths.length;
+      if (removed > 0) {
+        // 同步更新 songs 列表
+        if (playlist.songs != null) {
+          playlist.songs!.removeWhere(
+            (song) => removedNormalized.contains(p.normalize(song.filePath).toLowerCase()),
+          );
+        }
+        affectedIndices.add(i);
+        totalRemoved += removed;
+      }
     }
 
-    await _savePlaylists();
-    await _updateAllSongsList();
+    if (totalRemoved > 0) {
+      await _savePlaylists();
 
-    notifyListeners();
+      if (affectedIndices.contains(_selectedIndex)) {
+        _currentPlaylistSongs = _playlists[_selectedIndex].songs ?? [];
+      }
+
+      await _updateAllSongsList();
+      notifyListeners();
+    }
 
     return totalRemoved;
   }
@@ -3990,13 +4105,20 @@ class PlaylistContentNotifier extends ChangeNotifier {
       return;
     }
 
-    final newSongList = List<Song>.from(_currentPlaylistSongs);
-    final songToMove = newSongList.removeAt(index);
-    newSongList.insert(0, songToMove);
-    _currentPlaylistSongs = newSongList; // 指向新列表
+    final songToMove = _currentPlaylistSongs.removeAt(index);
+    _currentPlaylistSongs.insert(0, songToMove);
 
-    final songPath = _playlists[_selectedIndex].songFilePaths.removeAt(index);
-    _playlists[_selectedIndex].songFilePaths.insert(0, songPath);
+    // 同步更新 playlist.songs 以保持引用一致
+    final playlist = _playlists[_selectedIndex];
+    if (playlist.songs != null && identical(_currentPlaylistSongs, playlist.songs)) {
+      // _currentPlaylistSongs 就是 playlist.songs 的引用，已同步
+    } else if (playlist.songs != null) {
+      playlist.songs!.removeAt(index);
+      playlist.songs!.insert(0, songToMove);
+    }
+
+    final songPath = playlist.songFilePaths.removeAt(index);
+    playlist.songFilePaths.insert(0, songPath);
 
     // 如果当前播放的歌曲被移动，更新 currentSongIndex
     if (_currentSongIndex == index) {
@@ -4161,6 +4283,101 @@ class PlaylistContentNotifier extends ChangeNotifier {
         : '成功添加 ${newSongPaths.length} 首歌曲到歌单"${targetPlaylist.name}"';
 
     _infoStreamController.add(message);
+  }
+
+  // 按歌单ID添加歌曲路径（支持所有歌单类型，包括文件夹歌单）
+  // 返回实际新增的歌曲数量
+  Future<int> addSongsToPlaylistById(
+    String playlistId,
+    List<String> songPaths,
+  ) async {
+    final index = _playlists.indexWhere((p) => p.id == playlistId);
+    if (index < 0) return 0;
+
+    final targetPlaylist = _playlists[index];
+
+    // 过滤掉已经存在的路径
+    final existingSet = targetPlaylist.songFilePaths.map((fp) => p.normalize(fp).toLowerCase()).toSet();
+    final newPaths = songPaths
+        .where((path) => !existingSet.contains(p.normalize(path).toLowerCase()))
+        .toList();
+
+    if (newPaths.isEmpty) return 0;
+
+    // 添加新歌曲路径
+    targetPlaylist.songFilePaths.addAll(newPaths);
+
+    // 如果歌单已解析过歌曲，则解析并添加新歌曲
+    if (targetPlaylist.songs != null) {
+      final parsedSongs = await Future.wait(
+        newPaths.map((path) => _parseSongMetadata(path)),
+      );
+      targetPlaylist.songs!.addAll(parsedSongs);
+    }
+
+    await _savePlaylists();
+
+    if (_selectedIndex == index) {
+      if (targetPlaylist.songs != null) {
+        _currentPlaylistSongs = targetPlaylist.songs!;
+      } else {
+        await _loadCurrentPlaylistSongs();
+      }
+    }
+
+    await _updateAllSongsList();
+    notifyListeners();
+
+    return newPaths.length;
+  }
+
+  /// 批量为多个歌单添加歌曲，仅执行一次保存和更新
+  Future<int> addSongsToPlaylists(Map<String, List<String>> songsMap) async {
+    int totalAdded = 0;
+    final affectedIndices = <int>{};
+
+    for (final entry in songsMap.entries) {
+      final playlistId = entry.key;
+      final songPaths = entry.value;
+      final index = _playlists.indexWhere((p) => p.id == playlistId);
+      if (index < 0) continue;
+
+      final targetPlaylist = _playlists[index];
+      final existingSet = targetPlaylist.songFilePaths
+          .map((fp) => p.normalize(fp).toLowerCase())
+          .toSet();
+      final newPaths = songPaths
+          .where(
+              (path) => !existingSet.contains(p.normalize(path).toLowerCase()))
+          .toList();
+
+      if (newPaths.isEmpty) continue;
+
+      targetPlaylist.songFilePaths.addAll(newPaths);
+
+      if (targetPlaylist.songs != null) {
+        final parsedSongs = await Future.wait(
+          newPaths.map((path) => _parseSongMetadata(path)),
+        );
+        targetPlaylist.songs!.addAll(parsedSongs);
+      }
+
+      affectedIndices.add(index);
+      totalAdded += newPaths.length;
+    }
+
+    if (totalAdded == 0) return 0;
+
+    await _savePlaylists();
+
+    if (affectedIndices.contains(_selectedIndex)) {
+      await _loadCurrentPlaylistSongs();
+    }
+
+    await _updateAllSongsList();
+    notifyListeners();
+
+    return totalAdded;
   }
 
   // -------

--- a/lib/page/setting/folder_playlist_refresher.dart
+++ b/lib/page/setting/folder_playlist_refresher.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+import '../playlist/playlist_content_notifier.dart';
+import '../playlist/playlist_models.dart';
+
+class FolderPlaylistRefresher extends StatefulWidget {
+  final PlaylistContentNotifier notifier;
+
+  const FolderPlaylistRefresher({super.key, required this.notifier});
+
+  @override
+  State<FolderPlaylistRefresher> createState() => _FolderPlaylistRefresherState();
+}
+
+class _FolderPlaylistRefresherState extends State<FolderPlaylistRefresher> {
+  bool _isRefreshing = false;
+
+  Future<void> _showRefreshDialog() async {
+    final folderPlaylists = widget.notifier.playlists
+        .where((p) => p.isFolderBased)
+        .toList();
+
+    if (folderPlaylists.isEmpty) {
+      if (mounted) {
+        await showDialog(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('提示'),
+            content: const Text('没有文件夹歌单'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('确定'),
+              ),
+            ],
+          ),
+        );
+      }
+      return;
+    }
+
+    await showDialog(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return _FolderSelectionDialog(
+          playlists: folderPlaylists,
+          onStartRefresh: (selectedIds) {
+            Navigator.of(dialogContext).pop();
+            _startRefresh(selectedIds);
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _startRefresh(Set<String> playlistIds) async {
+    setState(() => _isRefreshing = true);
+
+    final folderPlaylists = widget.notifier.playlists
+        .where((p) => p.isFolderBased && playlistIds.contains(p.id))
+        .toList();
+
+    final changes = <String, ({List<String> added, List<String> removed})>{};
+    for (final playlist in folderPlaylists) {
+      final result =
+          await widget.notifier.refreshFolderPlaylistById(playlist.id);
+      if (!mounted) return;
+      if (result.added.isNotEmpty || result.removed.isNotEmpty) {
+        changes[playlist.name] = result;
+      }
+    }
+
+    setState(() => _isRefreshing = false);
+
+    if (!mounted) return;
+
+    if (changes.isEmpty) {
+      await showDialog(
+        context: context,
+        builder: (c) => AlertDialog(
+          title: const Text('刷新完成'),
+          content: const Text('所有文件夹歌单无变化'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(c).pop(),
+              child: const Text('确定'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      await showDialog(
+        context: context,
+        builder: (c) => AlertDialog(
+          title: const Text('文件夹歌单刷新完成'),
+          content: SizedBox(
+            width: 500,
+            height: MediaQuery.of(c).size.height * 0.6,
+            child: ClipRect(
+              child: Scrollbar(
+                thumbVisibility: true,
+                child: SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  child: _buildChangeContent(changes),
+                ),
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(c).pop(),
+              child: const Text('确定'),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  Widget _buildChangeContent(
+      Map<String, ({List<String> added, List<String> removed})> changes) {
+    final children = <Widget>[];
+    for (final entry in changes.entries) {
+      final name = entry.key;
+      final added = entry.value.added;
+      final removed = entry.value.removed;
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '歌单 "$name"',
+                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+              ),
+              if (removed.isNotEmpty) ...[
+                Padding(
+                  padding: const EdgeInsets.only(left: 8, top: 4),
+                  child: Text(
+                    '移除 ${removed.length} 首:',
+                    style: TextStyle(color: Colors.red.shade700, fontSize: 15),
+                  ),
+                ),
+                ...removed.map((path) => Padding(
+                      padding: const EdgeInsets.only(left: 24),
+                      child: Text(
+                        '• ${p.basename(path)}',
+                        style: TextStyle(
+                            color: Colors.red.shade700, fontSize: 14),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    )),
+              ],
+              if (added.isNotEmpty) ...[
+                Padding(
+                  padding: const EdgeInsets.only(left: 8, top: 4),
+                  child: Text(
+                    '新增 ${added.length} 首:',
+                    style: TextStyle(
+                        color: Colors.green.shade700, fontSize: 15),
+                  ),
+                ),
+                ...added.map((path) => Padding(
+                      padding: const EdgeInsets.only(left: 24),
+                      child: Text(
+                        '• ${p.basename(path)}',
+                        style: TextStyle(
+                            color: Colors.green.shade700, fontSize: 14),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    )),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text('刷新文件夹歌单', style: Theme.of(context).textTheme.titleMedium),
+        ElevatedButton.icon(
+          onPressed: _isRefreshing ? null : _showRefreshDialog,
+          icon: _isRefreshing
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.sync, size: 20),
+          label: const Text('开始刷新'),
+        ),
+      ],
+    );
+  }
+}
+
+/// 文件夹歌单选择对话框
+class _FolderSelectionDialog extends StatefulWidget {
+  final List<Playlist> playlists;
+  final void Function(Set<String> selectedIds) onStartRefresh;
+
+  const _FolderSelectionDialog({
+    required this.playlists,
+    required this.onStartRefresh,
+  });
+
+  @override
+  State<_FolderSelectionDialog> createState() => _FolderSelectionDialogState();
+}
+
+class _FolderSelectionDialogState extends State<_FolderSelectionDialog> {
+  late Set<String> _selectedIds;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIds = widget.playlists.map((p) => p.id).toSet();
+  }
+
+  bool get _isAllSelected => _selectedIds.length == widget.playlists.length;
+
+  void _toggleAll() {
+    setState(() {
+      if (_isAllSelected) {
+        _selectedIds.clear();
+      } else {
+        _selectedIds = widget.playlists.map((p) => p.id).toSet();
+      }
+    });
+  }
+
+  void _togglePlaylist(String id) {
+    setState(() {
+      if (_selectedIds.contains(id)) {
+        _selectedIds.remove(id);
+      } else {
+        _selectedIds.add(id);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('选择文件夹歌单'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CheckboxListTile(
+              value: _isAllSelected,
+              onChanged: (_) => _toggleAll(),
+              title: Text(_isAllSelected ? '取消全选' : '全选'),
+              controlAffinity: ListTileControlAffinity.leading,
+              dense: true,
+            ),
+            const Divider(height: 1),
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: widget.playlists.length,
+                itemBuilder: (context, index) {
+                  final playlist = widget.playlists[index];
+                  return CheckboxListTile(
+                    value: _selectedIds.contains(playlist.id),
+                    onChanged: (_) => _togglePlaylist(playlist.id),
+                    title: Row(
+                      children: [
+                        const Padding(
+                          padding: EdgeInsets.only(right: 4),
+                          child: Icon(Icons.folder, size: 16),
+                        ),
+                        Flexible(
+                          child: Text(
+                            playlist.name,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                    subtitle: Text(
+                      '${playlist.songFilePaths.length} 首歌曲',
+                    ),
+                    controlAffinity: ListTileControlAffinity.leading,
+                    dense: true,
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('取消'),
+        ),
+        ElevatedButton(
+          onPressed: _selectedIds.isEmpty
+              ? null
+              : () => widget.onStartRefresh(_selectedIds),
+          child: const Text('开始刷新'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/page/setting/playlist_cleaner.dart
+++ b/lib/page/setting/playlist_cleaner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
 import '../playlist/playlist_content_notifier.dart';
+import '../playlist/playlist_models.dart';
 
 class PlaylistCleaner extends StatefulWidget {
   final PlaylistContentNotifier notifier;
@@ -13,77 +14,102 @@ class PlaylistCleaner extends StatefulWidget {
 
 class _PlaylistCleanerState extends State<PlaylistCleaner> {
   bool _isScanning = false;
-  bool _isCleaning = false;
-  bool _hasScanned = false;
-  Map<String, List<String>>? _invalidFiles;
+  bool _isApplying = false;
+  Map<String, MapEntry<String, List<String>>>? _invalidFiles;
   String? _error;
 
   Future<void> _showCleanDialog() async {
-    // 重置状态
+    // 仅显示普通歌单
+    final playlists = widget.notifier.playlists
+        .where((p) => !p.isFolderBased)
+        .toList();
+
+    if (playlists.isEmpty) {
+      if (mounted) {
+        await showDialog(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('提示'),
+            content: const Text('没有可扫描的普通歌单'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('确定'),
+              ),
+            ],
+          ),
+        );
+      }
+      return;
+    }
+
     setState(() {
       _isScanning = false;
-      _isCleaning = false;
-      _hasScanned = false;
+      _isApplying = false;
       _invalidFiles = null;
       _error = null;
     });
 
+    if (!mounted) return;
+
     await showDialog(
       context: context,
       builder: (BuildContext dialogContext) {
-        return StatefulBuilder(
-          builder: (BuildContext dialogContext, StateSetter setDialogState) {
-            if (!_hasScanned && !_isScanning && !_isCleaning) {
-              _startScan(setDialogState);
-            }
-
-            return AlertDialog(
-              title: Text(
-                _isScanning
-                    ? '正在扫描...'
-                    : _isCleaning
-                    ? '正在清理...'
-                    : '清理歌单',
-              ),
-              content: _buildDialogContent(setDialogState),
-              actions: _isScanning || _isCleaning
-                  ? []
-                  : [
-                      TextButton(
-                        onPressed: () {
-                          Navigator.of(dialogContext).pop();
-                        },
-                        child: const Text('取消'),
-                      ),
-                      if (_invalidFiles != null && _invalidFiles!.isNotEmpty)
-                        TextButton(
-                          onPressed: () {
-                            _startClean(setDialogState);
-                          },
-                          child: const Text('清理'),
-                        ),
-                    ],
-            );
+        return _PlaylistSelectionDialog(
+          playlists: playlists,
+          onStartScan: (selectedIds) {
+            Navigator.of(dialogContext).pop();
+            _startScanAndShowResults(selectedIds);
           },
         );
       },
     );
   }
 
-  Future<void> _startScan(StateSetter setDialogState) async {
-    setDialogState(() {
+  Future<void> _startScanAndShowResults(Set<String> playlistIds) async {
+    setState(() {
       _isScanning = true;
-      _hasScanned = true;
+      _invalidFiles = null;
+      _error = null;
     });
 
+    if (!mounted) return;
+    bool hasStarted = false;
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            if (!hasStarted) {
+              hasStarted = true;
+              _runScan(ctx, setDialogState, playlistIds);
+            }
+            return _buildProgressDialog(ctx, setDialogState);
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _runScan(
+    BuildContext dialogContext,
+    StateSetter setDialogState,
+    Set<String> playlistIds,
+  ) async {
     try {
-      final invalidFiles = await widget.notifier.findInvalidFiles();
+      final idList = playlistIds.toList();
+      final invalidFiles =
+          await widget.notifier.findInvalidFiles(playlistIds: idList);
+
+      if (!dialogContext.mounted) return;
       setDialogState(() {
         _invalidFiles = invalidFiles;
         _isScanning = false;
         _error = null;
       });
     } catch (e) {
+      if (!dialogContext.mounted) return;
       setDialogState(() {
         _isScanning = false;
         _error = e.toString();
@@ -91,145 +117,135 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
     }
   }
 
-  Future<void> _startClean(StateSetter setDialogState) async {
-    setDialogState(() {
-      _isCleaning = true;
-    });
-
-    try {
-      final cleanedCount = await widget.notifier.cleanInvalidFiles();
-
-      if (!mounted) return;
-      Navigator.of(context).pop();
-
-      if (mounted) {
-        await showDialog(
-          context: context,
-          builder: (BuildContext context) {
-            return AlertDialog(
-              title: const Text('清理完成'),
-              content: Text('已清理 $cleanedCount 个不存在的文件'),
-              actions: [
-                TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
-                  child: const Text('确定'),
-                ),
-              ],
-            );
-          },
-        );
-      }
-    } catch (e) {
-      setDialogState(() {
-        _isCleaning = false;
-      });
-
-      if (mounted) {
-        await showDialog(
-          context: context,
-          builder: (BuildContext context) {
-            return AlertDialog(
-              title: const Text('清理失败'),
-              content: Text('清理过程中发生错误: $e'),
-              actions: [
-                TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
-                  child: const Text('确定'),
-                ),
-              ],
-            );
-          },
-        );
-      }
-    }
-  }
-
-  Widget _buildDialogContent(StateSetter setDialogState) {
+  Widget _buildProgressDialog(BuildContext ctx, StateSetter setDialogState) {
     if (_isScanning) {
-      return const SizedBox(
-        width: 400,
-        height: 100,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircularProgressIndicator(),
-            SizedBox(height: 16),
-            Text('正在扫描...'),
-          ],
+      return const AlertDialog(
+        title: Text('正在扫描...'),
+        content: SizedBox(
+          width: 300,
+          height: 100,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('正在扫描歌单文件...'),
+            ],
+          ),
         ),
       );
     }
 
-    if (_isCleaning) {
-      return const SizedBox(
-        width: 400,
-        height: 100,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircularProgressIndicator(),
-            SizedBox(height: 16),
-            Text('正在清理无效文件...'),
-          ],
+    if (_isApplying) {
+      return const AlertDialog(
+        title: Text('正在清理...'),
+        content: SizedBox(
+          width: 300,
+          height: 100,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('正在清理普通歌单无效文件...'),
+            ],
+          ),
         ),
       );
     }
 
     if (_error != null) {
-      return Text('扫描错误: $_error');
-    }
-
-    if (_invalidFiles == null) {
-      return const Text('正在准备扫描...');
-    }
-
-    if (_invalidFiles!.isEmpty) {
-      return const Text('没有发现不存在的文件');
-    }
-
-    final List<Widget> fileWidgets = [];
-    int totalCount = 0;
-
-    _invalidFiles!.forEach((playlistName, filePaths) {
-      fileWidgets.add(
-        Padding(
-          padding: const EdgeInsets.only(top: 8.0),
-          child: Text('歌单 "$playlistName" (${filePaths.length} 个文件):'),
-        ),
-      );
-
-      for (final filePath in filePaths) {
-        fileWidgets.add(
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8.0),
-            child: Text(
-              '• ${p.basename(filePath)}',
-              overflow: TextOverflow.ellipsis,
-            ),
+      return AlertDialog(
+        title: const Text('扫描错误'),
+        content: Text('扫描过程中发生错误: $_error'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('确定'),
           ),
-        );
-      }
+        ],
+      );
+    }
 
-      totalCount += filePaths.length;
-    });
+    final invalidCount = _invalidFiles?.values.fold<int>(
+            0, (sum, e) => sum + e.value.length) ??
+        0;
 
-    return SizedBox(
-      width: 500,
-      height: 400,
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('发现 $totalCount 个不存在的文件：'),
-            const SizedBox(height: 16),
-            ...fileWidgets,
-          ],
-        ),
-      ),
+    if (invalidCount == 0) {
+      return AlertDialog(
+        title: const Text('扫描完成'),
+        content: const Text('没有发现无效文件'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('确定'),
+          ),
+        ],
+      );
+    }
+
+    return _ResultDialog(
+      invalidFiles: _invalidFiles,
+      onApply: (checkedInvalidPaths) async {
+        setDialogState(() {
+          _isApplying = true;
+        });
+        final navigator = Navigator.of(ctx);
+        try {
+          final removeMap = <String, Set<String>>{};
+          if (_invalidFiles != null) {
+            for (final entry in _invalidFiles!.entries) {
+              final playlistId = entry.key;
+              final paths = entry.value.value;
+              final checked = paths
+                  .where((fp) => checkedInvalidPaths.contains(fp))
+                  .toSet();
+              if (checked.isNotEmpty) {
+                removeMap[playlistId] = checked;
+              }
+            }
+          }
+          final cleaned =
+              await widget.notifier.cleanInvalidFiles(filesToRemove: removeMap);
+
+          if (!mounted || !ctx.mounted) return;
+          navigator.pop();
+          if (mounted) {
+            await showDialog(
+              context: context,
+              builder: (c) => AlertDialog(
+                title: const Text('清理完成'),
+                content: Text('已清理 $cleaned 个无效文件'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(c).pop(),
+                    child: const Text('确定'),
+                  ),
+                ],
+              ),
+            );
+          }
+        } catch (e) {
+          setDialogState(() {
+            _isApplying = false;
+          });
+          if (mounted) {
+            await showDialog(
+              context: context,
+              builder: (c) => AlertDialog(
+                title: const Text('操作失败'),
+                content: Text('清理过程中发生错误: $e'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(c).pop(),
+                    child: const Text('确定'),
+                  ),
+                ],
+              ),
+            );
+          }
+        }
+      },
     );
   }
 
@@ -238,7 +254,7 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text('清理无效文件', style: Theme.of(context).textTheme.titleMedium),
+        Text('清理普通歌单无效文件', style: Theme.of(context).textTheme.titleMedium),
         ElevatedButton.icon(
           onPressed: () {
             _showCleanDialog();
@@ -247,6 +263,270 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
           label: const Text('开始扫描'),
         ),
       ],
+    );
+  }
+}
+
+/// 第一步：歌单选择对话框
+class _PlaylistSelectionDialog extends StatefulWidget {
+  final List<Playlist> playlists;
+  final void Function(Set<String> selectedIds) onStartScan;
+
+  const _PlaylistSelectionDialog({
+    required this.playlists,
+    required this.onStartScan,
+  });
+
+  @override
+  State<_PlaylistSelectionDialog> createState() =>
+      _PlaylistSelectionDialogState();
+}
+
+class _PlaylistSelectionDialogState extends State<_PlaylistSelectionDialog> {
+  late Set<String> _selectedIds;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIds = widget.playlists.map((p) => p.id).toSet();
+  }
+
+  bool get _isAllSelected => _selectedIds.length == widget.playlists.length;
+
+  void _toggleAll() {
+    setState(() {
+      if (_isAllSelected) {
+        _selectedIds.clear();
+      } else {
+        _selectedIds = widget.playlists.map((p) => p.id).toSet();
+      }
+    });
+  }
+
+  void _togglePlaylist(String id) {
+    setState(() {
+      if (_selectedIds.contains(id)) {
+        _selectedIds.remove(id);
+      } else {
+        _selectedIds.add(id);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('选择歌单'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CheckboxListTile(
+              value: _isAllSelected,
+              onChanged: (_) => _toggleAll(),
+              title: Text(_isAllSelected ? '取消全选' : '全选'),
+              controlAffinity: ListTileControlAffinity.leading,
+              dense: true,
+            ),
+            const Divider(height: 1),
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: widget.playlists.length,
+                itemBuilder: (context, index) {
+                  final playlist = widget.playlists[index];
+                  return CheckboxListTile(
+                    value: _selectedIds.contains(playlist.id),
+                    onChanged: (_) => _togglePlaylist(playlist.id),
+                    title: Text(
+                      playlist.name,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: Text(
+                      '${playlist.songFilePaths.length} 首歌曲',
+                    ),
+                    controlAffinity: ListTileControlAffinity.leading,
+                    dense: true,
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('取消'),
+        ),
+        ElevatedButton(
+          onPressed: _selectedIds.isEmpty
+              ? null
+              : () => widget.onStartScan(_selectedIds),
+          child: const Text('开始扫描'),
+        ),
+      ],
+    );
+  }
+}
+
+/// 第二步：扫描结果对话框，带勾选功能
+class _ResultDialog extends StatefulWidget {
+  final Map<String, MapEntry<String, List<String>>>? invalidFiles;
+  final Future<void> Function(Set<String> checkedInvalidPaths) onApply;
+
+  const _ResultDialog({
+    required this.invalidFiles,
+    required this.onApply,
+  });
+
+  @override
+  State<_ResultDialog> createState() => _ResultDialogState();
+}
+
+class _ResultDialogState extends State<_ResultDialog> {
+  late Set<String> _checkedInvalidPaths;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkedInvalidPaths = {};
+    // 默认全选所有无效文件
+    if (widget.invalidFiles != null) {
+      for (final entry in widget.invalidFiles!.values) {
+        _checkedInvalidPaths.addAll(entry.value);
+      }
+    }
+  }
+
+  bool get _isAllInvalidSelected {
+    if (widget.invalidFiles == null || widget.invalidFiles!.isEmpty) return false;
+    return _invalidTotal > 0 && _invalidTotal == _checkedInvalidPaths.length;
+  }
+
+  int get _invalidTotal =>
+      widget.invalidFiles?.values.fold<int>(
+          0, (sum, e) => sum + e.value.length) ??
+      0;
+
+  void _toggleAllInvalid() {
+    final files = widget.invalidFiles;
+    if (files == null) return;
+    setState(() {
+      if (_isAllInvalidSelected) {
+        for (final entry in files.values) {
+          _checkedInvalidPaths.removeAll(entry.value);
+        }
+      } else {
+        for (final entry in files.values) {
+          _checkedInvalidPaths.addAll(entry.value);
+        }
+      }
+    });
+  }
+
+  void _toggleInvalidPath(String path) {
+    setState(() {
+      if (_checkedInvalidPaths.contains(path)) {
+        _checkedInvalidPaths.remove(path);
+      } else {
+        _checkedInvalidPaths.add(path);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final invalidCount = _invalidTotal;
+
+    final List<Widget> contentWidgets = [];
+
+    // 无效文件部分
+    if (widget.invalidFiles != null && widget.invalidFiles!.isNotEmpty) {
+      contentWidgets.add(
+        CheckboxListTile(
+          value: _isAllInvalidSelected,
+          onChanged: (_) => _toggleAllInvalid(),
+          title: Text(_isAllInvalidSelected
+              ? '取消全选无效文件'
+              : '全选无效文件 ($invalidCount)'),
+          controlAffinity: ListTileControlAffinity.leading,
+          dense: true,
+        ),
+      );
+      contentWidgets.add(const Divider(height: 1));
+
+      for (final entry in widget.invalidFiles!.entries) {
+        final playlistName = entry.value.key;
+        final paths = entry.value.value;
+        contentWidgets.add(
+          Padding(
+            padding: const EdgeInsets.only(top: 8, left: 8),
+            child: Text(
+              '歌单 "$playlistName" (${paths.length} 个文件):',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
+        );
+        for (final path in paths) {
+          contentWidgets.add(
+            CheckboxListTile(
+              value: _checkedInvalidPaths.contains(path),
+              onChanged: (_) => _toggleInvalidPath(path),
+              title: Text(
+                p.basename(path),
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(fontSize: 15),
+              ),
+              subtitle: path.length > 60
+                  ? Text(
+                      path,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontSize: 12),
+                    )
+                  : null,
+              controlAffinity: ListTileControlAffinity.leading,
+              dense: true,
+            ),
+          );
+        }
+      }
+    }
+
+    final actions = <Widget>[
+      TextButton(
+        onPressed: () => Navigator.of(context).pop(),
+        child: const Text('关闭'),
+      ),
+      ElevatedButton(
+        onPressed: _checkedInvalidPaths.isEmpty
+            ? null
+            : () => widget.onApply(_checkedInvalidPaths),
+        child: Text('清理 (${_checkedInvalidPaths.length})'),
+      ),
+    ];
+
+    return AlertDialog(
+      title: Text('扫描结果 (无效: $invalidCount)'),
+      content: SizedBox(
+        width: 500,
+        height: MediaQuery.of(context).size.height * 0.6,
+        child: ClipRect(
+          child: Scrollbar(
+            thumbVisibility: true,
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: contentWidgets,
+              ),
+            ),
+          ),
+        ),
+      ),
+      actions: actions,
     );
   }
 }

--- a/lib/page/setting/setting_page.dart
+++ b/lib/page/setting/setting_page.dart
@@ -16,6 +16,7 @@ import 'artist_separator.dart';
 import 'about.dart';
 import 'page_visibility_settings.dart';
 import 'playlist_cleaner.dart';
+import 'folder_playlist_refresher.dart';
 
 // 定义应用版本号常量
 const String appVersion = '0.9.0';
@@ -754,6 +755,18 @@ class _SettingPageState extends State<SettingPage>
                     child: Consumer<PlaylistContentNotifier>(
                       builder: (context, notifier, child) {
                         return PlaylistCleaner(notifier: notifier);
+                      },
+                    ),
+                  ),
+                  // 刷新文件夹歌单
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 6,
+                    ),
+                    child: Consumer<PlaylistContentNotifier>(
+                      builder: (context, notifier, child) {
+                        return FolderPlaylistRefresher(notifier: notifier);
                       },
                     ),
                   ),

--- a/lib/page/song_detail_page.dart
+++ b/lib/page/song_detail_page.dart
@@ -155,7 +155,7 @@ class _BackgroundBlurWidgetState extends State<BackgroundBlurWidget>
   void _manageAnimation(bool shouldAnimate) {
     if (shouldAnimate) {
       if (!_animationController.isAnimating) {
-        _animationController.repeat();
+        _animationController.repeat(reverse: true);// 重复播放，反向播放
       }
     } else {
       if (_animationController.isAnimating) {


### PR DESCRIPTION
普通歌单
<img width="979" height="644" alt="image" src="https://github.com/user-attachments/assets/f6af3462-ce23-436a-bec0-5acf70c92c7c" />
<img width="979" height="644" alt="image" src="https://github.com/user-attachments/assets/ace3a462-7c86-4118-95a3-5ae194f283df" />

文件夹歌单
<img width="979" height="644" alt="image" src="https://github.com/user-attachments/assets/2ca92592-bca3-43bd-bf00-94a276302028" />
<img width="979" height="644" alt="image" src="https://github.com/user-attachments/assets/f1a8e4af-a6b4-41bf-9945-8227bb7401fe" />

