### PR TITLE
fix(playlist): 修复 PR#96 审查问题

### DIFF
--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -1448,7 +1448,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
         playlist.songs = songs;
       }
 
-      _savePlaylists();
+      await _savePlaylists();
 
       // 如果当前选中的就是这个播放列表，则更新当前播放列表歌曲
       if (_selectedIndex == _playlists.indexOf(playlist)) {
@@ -2828,8 +2828,16 @@ class PlaylistContentNotifier extends ChangeNotifier {
     final song = _currentPlaylistSongs.removeAt(oldIndex);
     _currentPlaylistSongs.insert(newIndex, song);
 
-    // 确保数据同步
+    // 同步更新 playlist.songs（引用一致时已随 _currentPlaylistSongs 同步）
     final currentPlaylist = _playlists[_selectedIndex];
+    if (currentPlaylist.songs != null &&
+        !identical(_currentPlaylistSongs, currentPlaylist.songs) &&
+        oldIndex >= 0 && oldIndex < currentPlaylist.songs!.length &&
+        newIndex >= 0 && newIndex <= currentPlaylist.songs!.length) {
+      currentPlaylist.songs!.removeAt(oldIndex);
+      currentPlaylist.songs!.insert(newIndex, song);
+    }
+
     final movedPath = currentPlaylist.songFilePaths.removeAt(oldIndex);
     currentPlaylist.songFilePaths.insert(newIndex, movedPath);
 
@@ -4214,12 +4222,11 @@ class PlaylistContentNotifier extends ChangeNotifier {
     final songToMove = _currentPlaylistSongs.removeAt(index);
     _currentPlaylistSongs.insert(0, songToMove);
 
-    // 同步更新 playlist.songs 以保持引用一致
+    // 同步更新 playlist.songs（引用一致时已随 _currentPlaylistSongs 同步）
     final playlist = _playlists[_selectedIndex];
     if (playlist.songs != null &&
-        identical(_currentPlaylistSongs, playlist.songs)) {
-      // _currentPlaylistSongs 就是 playlist.songs 的引用，已同步
-    } else if (playlist.songs != null) {
+        !identical(_currentPlaylistSongs, playlist.songs) &&
+        index >= 0 && index < playlist.songs!.length) {
       playlist.songs!.removeAt(index);
       playlist.songs!.insert(0, songToMove);
     }

--- a/lib/page/setting/folder_playlist_refresher.dart
+++ b/lib/page/setting/folder_playlist_refresher.dart
@@ -17,6 +17,8 @@ class _FolderPlaylistRefresherState extends State<FolderPlaylistRefresher> {
   bool _isRefreshing = false;
 
   Future<void> _showRefreshDialog() async {
+    if (_isRefreshing) return;
+
     final folderPlaylists = widget.notifier.playlists
         .where((p) => p.isFolderBased)
         .toList();
@@ -237,11 +239,18 @@ class _FolderSelectionDialog extends StatefulWidget {
 
 class _FolderSelectionDialogState extends State<_FolderSelectionDialog> {
   late Set<String> _selectedIds;
+  final ScrollController _scrollController = ScrollController();
 
   @override
   void initState() {
     super.initState();
     _selectedIds = widget.playlists.map((p) => p.id).toSet();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   bool get _isAllSelected => _selectedIds.length == widget.playlists.length;
@@ -272,8 +281,8 @@ class _FolderSelectionDialogState extends State<_FolderSelectionDialog> {
       title: const Text('选择文件夹歌单'),
       content: SizedBox(
         width: 400,
+        height: MediaQuery.of(context).size.height * 0.5,
         child: Column(
-          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             CheckboxListTile(
@@ -284,34 +293,39 @@ class _FolderSelectionDialogState extends State<_FolderSelectionDialog> {
               dense: true,
             ),
             const Divider(height: 1),
-            Flexible(
-              child: ListView.builder(
-                shrinkWrap: true,
-                itemCount: widget.playlists.length,
-                itemBuilder: (context, index) {
-                  final playlist = widget.playlists[index];
-                  return CheckboxListTile(
-                    value: _selectedIds.contains(playlist.id),
-                    onChanged: (_) => _togglePlaylist(playlist.id),
-                    title: Row(
-                      children: [
-                        const Padding(
-                          padding: EdgeInsets.only(right: 4),
-                          child: Icon(Icons.folder, size: 16),
-                        ),
-                        Flexible(
-                          child: Text(
-                            playlist.name,
-                            overflow: TextOverflow.ellipsis,
+            Expanded(
+              child: Scrollbar(
+                controller: _scrollController,
+                thumbVisibility: true,
+                child: ListView.builder(
+                  controller: _scrollController,
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  itemCount: widget.playlists.length,
+                  itemBuilder: (context, index) {
+                    final playlist = widget.playlists[index];
+                    return CheckboxListTile(
+                      value: _selectedIds.contains(playlist.id),
+                      onChanged: (_) => _togglePlaylist(playlist.id),
+                      title: Row(
+                        children: [
+                          const Padding(
+                            padding: EdgeInsets.only(right: 4),
+                            child: Icon(Icons.folder, size: 16),
                           ),
-                        ),
-                      ],
-                    ),
-                    subtitle: Text('${playlist.songFilePaths.length} 首歌曲'),
-                    controlAffinity: ListTileControlAffinity.leading,
-                    dense: true,
-                  );
-                },
+                          Flexible(
+                            child: Text(
+                              playlist.name,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                      subtitle: Text('${playlist.songFilePaths.length} 首歌曲'),
+                      controlAffinity: ListTileControlAffinity.leading,
+                      dense: true,
+                    );
+                  },
+                ),
               ),
             ),
           ],

--- a/lib/page/setting/playlist_cleaner.dart
+++ b/lib/page/setting/playlist_cleaner.dart
@@ -83,7 +83,14 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
           builder: (ctx, setDialogState) {
             if (!hasStarted) {
               hasStarted = true;
-              _runScan(ctx, setDialogState, playlistIds);
+              _runScan(ctx, setDialogState, playlistIds).catchError((e) {
+                if (ctx.mounted) {
+                  setDialogState(() {
+                    _isScanning = false;
+                    _error = e.toString();
+                  });
+                }
+              });
             }
             return _buildProgressDialog(ctx, setDialogState);
           },
@@ -213,6 +220,7 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
           if (!mounted || !ctx.mounted) return;
           navigator.pop();
           if (mounted) {
+            setState(() => _isApplying = false);
             await showDialog(
               context: context,
               builder: (c) => AlertDialog(
@@ -228,10 +236,11 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
             );
           }
         } catch (e) {
-          setDialogState(() {
-            _isApplying = false;
-          });
+          if (ctx.mounted) {
+            navigator.pop();
+          }
           if (mounted) {
+            setState(() => _isApplying = false);
             await showDialog(
               context: context,
               builder: (c) => AlertDialog(
@@ -258,10 +267,15 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
       children: [
         Text('清理无效文件', style: Theme.of(context).textTheme.titleMedium),
         ElevatedButton.icon(
-          onPressed: () {
-            _showCleanDialog();
-          },
-          icon: const Icon(Icons.cleaning_services, size: 20),
+          onPressed:
+              (_isScanning || _isApplying) ? null : _showCleanDialog,
+          icon: (_isScanning || _isApplying)
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.cleaning_services, size: 20),
           label: const Text('开始扫描'),
         ),
       ],
@@ -286,11 +300,18 @@ class _PlaylistSelectionDialog extends StatefulWidget {
 
 class _PlaylistSelectionDialogState extends State<_PlaylistSelectionDialog> {
   late Set<String> _selectedIds;
+  final ScrollController _scrollController = ScrollController();
 
   @override
   void initState() {
     super.initState();
     _selectedIds = widget.playlists.map((p) => p.id).toSet();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   bool get _isAllSelected => _selectedIds.length == widget.playlists.length;
@@ -321,8 +342,8 @@ class _PlaylistSelectionDialogState extends State<_PlaylistSelectionDialog> {
       title: const Text('选择歌单'),
       content: SizedBox(
         width: 400,
+        height: MediaQuery.of(context).size.height * 0.5,
         child: Column(
-          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             CheckboxListTile(
@@ -333,21 +354,26 @@ class _PlaylistSelectionDialogState extends State<_PlaylistSelectionDialog> {
               dense: true,
             ),
             const Divider(height: 1),
-            Flexible(
-              child: ListView.builder(
-                shrinkWrap: true,
-                itemCount: widget.playlists.length,
-                itemBuilder: (context, index) {
-                  final playlist = widget.playlists[index];
-                  return CheckboxListTile(
-                    value: _selectedIds.contains(playlist.id),
-                    onChanged: (_) => _togglePlaylist(playlist.id),
-                    title: Text(playlist.name, overflow: TextOverflow.ellipsis),
-                    subtitle: Text('${playlist.songFilePaths.length} 首歌曲'),
-                    controlAffinity: ListTileControlAffinity.leading,
-                    dense: true,
-                  );
-                },
+            Expanded(
+              child: Scrollbar(
+                controller: _scrollController,
+                thumbVisibility: true,
+                child: ListView.builder(
+                  controller: _scrollController,
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  itemCount: widget.playlists.length,
+                  itemBuilder: (context, index) {
+                    final playlist = widget.playlists[index];
+                    return CheckboxListTile(
+                      value: _selectedIds.contains(playlist.id),
+                      onChanged: (_) => _togglePlaylist(playlist.id),
+                      title: Text(playlist.name, overflow: TextOverflow.ellipsis),
+                      subtitle: Text('${playlist.songFilePaths.length} 首歌曲'),
+                      controlAffinity: ListTileControlAffinity.leading,
+                      dense: true,
+                    );
+                  },
+                ),
               ),
             ),
           ],


### PR DESCRIPTION
- 修复 FolderPlaylistRefresher 刷新中 mounted return 未重置 _isRefreshing 导致按钮永久禁用
- 修复 FolderPlaylistRefresher 可重复点击触发并发刷新
- 修复 PlaylistCleaner 按钮在扫描/清理中未禁用
- 修复 _runScan 未捕获未预期异常导致对话框卡死
- 修复 onApply 异常时未关闭结果对话框就弹错误对话框
- 修复 moveSongToTop 中 identical 判断逻辑
- 为两个歌单选择对话框添加 Scrollbar 歌单过长不滚动