### PR TITLE
fix: 修复清理无效文件按钮状态不更新及其他问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Generated plugin registrants
+linux/flutter/generated_plugin_registrant.cc
+linux/flutter/generated_plugins.cmake
+windows/flutter/generated_plugin_registrant.cc
+windows/flutter/generated_plugins.cmake

--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -1340,6 +1340,56 @@ class PlaylistContentNotifier extends ChangeNotifier {
     return true; // 成功
   }
 
+  /// 跨平台路径差异计算：使用 Map<小写路径, Set<实际路径>> 处理大小写敏感/不敏感差异
+  /// - 大小写不敏感系统(Windows/macOS)：同名不同大小写视为同一文件，保留旧路径
+  /// - 大小写敏感系统(Linux)：保留所有实际路径的差异
+  ({List<String> added, List<String> removed}) _computePathDiff(
+    List<String> oldPaths,
+    Iterable<String> newRawPaths,
+  ) {
+    final oldMap = _buildPathMap(oldPaths);
+    final newMap = _buildPathMap(newRawPaths);
+
+    final oldKeys = oldMap.keys.toSet();
+    final newKeys = newMap.keys.toSet();
+    final commonKeys = newKeys.intersection(oldKeys);
+
+    final added = <String>[];
+    final removed = <String>[];
+
+    // 键仅在旧集合中 -> 删除
+    for (final key in oldKeys.difference(newKeys)) {
+      removed.addAll(oldMap[key]!);
+    }
+    // 键仅在新集合中 -> 新增
+    for (final key in newKeys.difference(oldKeys)) {
+      added.addAll(newMap[key]!);
+    }
+    // 共有键：大小写敏感系统(Linux)上需要检查实际路径差异
+    if (Platform.isLinux) {
+      for (final key in commonKeys) {
+        final oldActual = oldMap[key]!;
+        final newActual = newMap[key]!;
+        for (final fp in oldActual) {
+          if (!newActual.contains(fp)) removed.add(fp);
+        }
+        for (final fp in newActual) {
+          if (!oldActual.contains(fp)) added.add(fp);
+        }
+      }
+    }
+
+    return (added: added, removed: removed);
+  }
+
+  Map<String, Set<String>> _buildPathMap(Iterable<String> paths) {
+    final map = <String, Set<String>>{};
+    for (final fp in paths) {
+      map.putIfAbsent(p.normalize(fp).toLowerCase(), () => {}).add(fp);
+    }
+    return map;
+  }
+
   // 扫描文件夹并添加歌曲
   Future<void> _scanFoldersAndAddSongs(List<String> folderPaths) async {
     if (_selectedIndex < 0 || _selectedIndex >= _playlists.length) return;
@@ -1360,58 +1410,52 @@ class PlaylistContentNotifier extends ChangeNotifier {
           await for (final file in directory.list(
             recursive: true,
             followLinks: false,
-          )) {
+          ).handleError((_) {})) {
             if (file is File) {
               final extension = p.extension(file.path).toLowerCase();
               // 检查是否为支持的音频文件格式
               if (_supportedAudioExtensions.contains(extension)) {
-                songPaths.add(file.path);
+                songPaths.add(p.normalize(file.path));
               }
             }
           }
         }
       }
 
-      // 比较新旧歌曲路径集合，只添加或删除变化的部分
-      final oldSongPaths = playlist.songFilePaths.toSet();
-      final newSongPaths = songPaths;
+      // 使用跨平台路径差异计算
+      final diff = _computePathDiff(playlist.songFilePaths, songPaths);
+      final addedPaths = diff.added;
+      final removedPathsNormalized = diff.removed
+          .map((fp) => p.normalize(fp).toLowerCase())
+          .toSet();
 
-      // 找出新增的歌曲路径
-      final addedSongPaths = newSongPaths.difference(oldSongPaths);
-      // 找出删除的歌曲路径
-      final removedSongPaths = oldSongPaths.difference(newSongPaths);
+      // 先解析新增歌曲元数据，确认无异常后再修改 playlist 状态
+      // 仅在歌曲已加载时解析新增歌曲
+      final List<Song> newSongs = [];
+      if (playlist.songs != null) {
+        final parsed = await Future.wait(
+          addedPaths.map((path) => _parseSongMetadata(path)),
+        );
+        newSongs.addAll(parsed);
+      }
 
+      // 所有解析成功后，统一修改 playlist 状态
       // 从现有列表中移除已删除的歌曲
       playlist.songFilePaths.removeWhere(
-        (path) => removedSongPaths.contains(path),
+        (path) => removedPathsNormalized.contains(p.normalize(path).toLowerCase()),
       );
 
       // 添加新增的歌曲到末尾
-      playlist.songFilePaths.addAll(addedSongPaths);
+      playlist.songFilePaths.addAll(addedPaths);
 
-      // 解析新增歌曲的元数据
-      final List<Song> newSongs = [];
-      for (final path in addedSongPaths) {
-        final song = await _parseSongMetadata(path);
-        newSongs.add(song);
-      }
-
-      // 更新播放列表的歌曲对象列表
+      // 更新播放列表的歌曲对象列表（仅在已加载时维护）
       if (playlist.songs != null) {
-        // 移除已删除的歌曲对象
         playlist.songs!.removeWhere(
-          (song) => removedSongPaths.contains(song.filePath),
+          (song) => removedPathsNormalized.contains(
+            p.normalize(song.filePath).toLowerCase(),
+          ),
         );
-        // 添加新增的歌曲对象
         playlist.songs!.addAll(newSongs);
-      } else {
-        // 如果之前没有解析过歌曲，则全部重新解析
-        final List<Song> songs = [];
-        for (final path in playlist.songFilePaths) {
-          final song = await _parseSongMetadata(path);
-          songs.add(song);
-        }
-        playlist.songs = songs;
       }
 
       await _savePlaylists();
@@ -1425,9 +1469,9 @@ class PlaylistContentNotifier extends ChangeNotifier {
       await _updateAllSongsList();
 
       // 显示操作结果信息
-      if (addedSongPaths.isNotEmpty || removedSongPaths.isNotEmpty) {
+      if (addedPaths.isNotEmpty || removedPathsNormalized.isNotEmpty) {
         _infoStreamController.add(
-          '刷新完成：新增 ${addedSongPaths.length} 首歌曲，移除 ${removedSongPaths.length} 首歌曲',
+          '刷新完成：新增 ${addedPaths.length} 首歌曲，移除 ${removedPathsNormalized.length} 首歌曲',
         );
       } else {
         _infoStreamController.add('刷新完成：没有发现变化');
@@ -1474,39 +1518,34 @@ class PlaylistContentNotifier extends ChangeNotifier {
       }
     }
 
-    final oldSongPaths = playlist.songFilePaths
+    final diff = _computePathDiff(playlist.songFilePaths, songPaths);
+    final addedPaths = diff.added;
+    final removedPathsNormalized = diff.removed
         .map((fp) => p.normalize(fp).toLowerCase())
         .toSet();
-    final newSongPaths = songPaths.map((fp) => fp.toLowerCase()).toSet();
 
-    final addedSongPaths = newSongPaths.difference(oldSongPaths).toList();
-    final removedSongPaths = oldSongPaths.difference(newSongPaths);
+    // 先解析新增歌曲元数据，确认无异常后再修改 playlist 状态
+    // 仅在歌曲已加载时解析新增歌曲
+    List<Song>? parsedAddedSongs;
+    if (playlist.songs != null) {
+      parsedAddedSongs = await Future.wait(
+        addedPaths.map((path) => _parseSongMetadata(path)),
+      );
+    }
 
+    // 所有解析成功后，统一修改 playlist 状态
     playlist.songFilePaths.removeWhere(
-      (path) => removedSongPaths.contains(p.normalize(path).toLowerCase()),
+      (path) => removedPathsNormalized.contains(p.normalize(path).toLowerCase()),
     );
-
-    // addedSongPaths 是小写差集，需从原始 songPaths 中找回实际路径
-    final actualAddedPaths = songPaths
-        .where((fp) => addedSongPaths.contains(fp.toLowerCase()))
-        .toList();
-    playlist.songFilePaths.addAll(actualAddedPaths);
+    playlist.songFilePaths.addAll(addedPaths);
 
     if (playlist.songs != null) {
       playlist.songs!.removeWhere(
-        (song) =>
-            removedSongPaths.contains(p.normalize(song.filePath).toLowerCase()),
+        (song) => removedPathsNormalized.contains(
+          p.normalize(song.filePath).toLowerCase(),
+        ),
       );
-
-      final parsedSongs = await Future.wait(
-        actualAddedPaths.map((path) => _parseSongMetadata(path)),
-      );
-      playlist.songs!.addAll(parsedSongs);
-    } else {
-      final parsedSongs = await Future.wait(
-        playlist.songFilePaths.map((path) => _parseSongMetadata(path)),
-      );
-      playlist.songs = parsedSongs.toList();
+      playlist.songs!.addAll(parsedAddedSongs!);
     }
 
     await _savePlaylists();
@@ -1518,7 +1557,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
     await _updateAllSongsList();
     notifyListeners();
 
-    return (added: actualAddedPaths, removed: removedSongPaths.toList());
+    return (added: addedPaths, removed: diff.removed);
   }
 
   // 更新播放列表的文件夹路径

--- a/lib/page/setting/folder_playlist_refresher.dart
+++ b/lib/page/setting/folder_playlist_refresher.dart
@@ -64,13 +64,20 @@ class _FolderPlaylistRefresherState extends State<FolderPlaylistRefresher> {
         .toList();
 
     final changes = <String, ({List<String> added, List<String> removed})>{};
+    final failedNames = <String>[];
     for (final playlist in folderPlaylists) {
-      final result = await widget.notifier.refreshFolderPlaylistById(
-        playlist.id,
-      );
-      if (!mounted) return;
-      if (result.added.isNotEmpty || result.removed.isNotEmpty) {
-        changes[playlist.name] = result;
+      try {
+        final result = await widget.notifier.refreshFolderPlaylistById(
+          playlist.id,
+        );
+        if (!mounted) return;
+        if (result.added.isNotEmpty || result.removed.isNotEmpty) {
+          changes[playlist.name] = result;
+        }
+      } catch (e) {
+        debugPrint('刷新歌单 "${playlist.name}" 失败: $e');
+        failedNames.add(playlist.name);
+        if (!mounted) return;
       }
     }
 
@@ -78,7 +85,7 @@ class _FolderPlaylistRefresherState extends State<FolderPlaylistRefresher> {
 
     if (!mounted) return;
 
-    if (changes.isEmpty) {
+    if (changes.isEmpty && failedNames.isEmpty) {
       await showDialog(
         context: context,
         builder: (c) => AlertDialog(
@@ -105,7 +112,7 @@ class _FolderPlaylistRefresherState extends State<FolderPlaylistRefresher> {
                 thumbVisibility: true,
                 child: SingleChildScrollView(
                   physics: const AlwaysScrollableScrollPhysics(),
-                  child: _buildChangeContent(changes),
+                  child: _buildChangeContent(changes, failedNames),
                 ),
               ),
             ),
@@ -123,6 +130,7 @@ class _FolderPlaylistRefresherState extends State<FolderPlaylistRefresher> {
 
   Widget _buildChangeContent(
     Map<String, ({List<String> added, List<String> removed})> changes,
+    List<String> failedNames,
   ) {
     final children = <Widget>[];
     for (final entry in changes.entries) {
@@ -191,6 +199,38 @@ class _FolderPlaylistRefresherState extends State<FolderPlaylistRefresher> {
               ],
             ],
           ),
+        ),
+      );
+    }
+    if (failedNames.isNotEmpty) {
+      children.add(
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                '刷新失败 (${failedNames.length} 个):',
+                style: TextStyle(
+                  color: Colors.orange.shade700,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 15,
+                ),
+              ),
+            ),
+            ...failedNames.map(
+              (name) => Padding(
+                padding: const EdgeInsets.only(left: 24),
+                child: Text(
+                  '• $name',
+                  style: TextStyle(
+                    color: Colors.orange.shade700,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       );
     }

--- a/lib/page/setting/playlist_cleaner.dart
+++ b/lib/page/setting/playlist_cleaner.dart
@@ -83,20 +83,21 @@ class _PlaylistCleanerState extends State<PlaylistCleaner> {
           builder: (ctx, setDialogState) {
             if (!hasStarted) {
               hasStarted = true;
-              _runScan(ctx, setDialogState, playlistIds).catchError((e) {
-                if (ctx.mounted) {
-                  setDialogState(() {
-                    _isScanning = false;
-                    _error = e.toString();
-                  });
-                }
-              });
+              _runScan(ctx, setDialogState, playlistIds);
             }
             return _buildProgressDialog(ctx, setDialogState);
           },
         );
       },
     );
+
+    // 确保对话框关闭后重置状态并重建父组件，同步按钮状态
+    if (mounted) {
+      setState(() {
+        _isScanning = false;
+        _isApplying = false;
+      });
+    }
   }
 
   Future<void> _runScan(

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -39,7 +39,7 @@ add_definitions(-DUNICODE -D_UNICODE)
 # of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
-  target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
+  target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100" /wd"4819")
   target_compile_options(${TARGET} PRIVATE /EHsc)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")


### PR DESCRIPTION

### Bug 修复

- **修复「清理无效文件」按钮扫描后永久禁用问题**
  对话框关闭后显式重置 `_isScanning` / `_isApplying` 为 `false`，确保按钮状态在任何关闭方式下都能恢复

- **修复「刷新文件夹歌单」按钮刷新失败后永久禁用问题**
  为 `_startRefresh` 循环添加 try-catch，单个歌单刷新失败不阻断其余歌单处理；失败歌单在结果对话框中用橙色标识展示

- **修复路径规范化不一致导致重复条目问题**
  `_scanFoldersAndAddSongs` 扫描路径未规范化，与 `refreshFolderPlaylistById` 行为不一致，同一文件可能以不同格式存入 `songFilePaths`，现已统一使用 `p.normalize()`

- **修复歌曲移除时路径比较方式不一致问题**
  `cleanInvalidFiles` 使用规范化+小写匹配，而 `_scanFoldersAndAddSongs` / `refreshFolderPlaylistById` 使用精确字符串匹配，现已统一为 `p.normalize(fp).toLowerCase()` 比较

- **修复元数据解析异常时内存状态不一致问题**
  `_scanFoldersAndAddSongs` / `refreshFolderPlaylistById` 先修改 `songFilePaths` 再解析元数据，若解析失败则内存状态已变但未持久化。现已重构为先解析元数据、确认无异常后再统一修改 playlist 状态

- **移除冗余的 `.catchError` 调用**
  `_runScan` 内部已有 try-catch 处理所有异常，外层 `.catchError` 永远不会被触发

### 性能

  当 `playlist.songs == null` 时，`_scanFoldersAndAddSongs` / `refreshFolderPlaylistById` 不再强制解析全部歌曲元数据，仅更新 `songFilePaths`

- **并行解析新增歌曲元数据**
  `_scanFoldersAndAddSongs` 的新增歌曲解析从串行 `for` 循环改为 `Future.wait` 并行，与 `refreshFolderPlaylistById` 保持一致

### 重构：路径比较机制

- 新增 `_computePathDiff` / `_buildPathMap` 辅助方法
- 使用 `Map<小写路径, Set<实际路径>>` 同时处理大小写敏感和不敏感文件系统
  - Windows/macOS：同名不同大小写视为同一文件，保留旧路径
  - Linux（大小写敏感）：保留所有实际路径差异，`Track.mp3` 和 `track.mp3` 作为不同文件
- 统一 `_scanFoldersAndAddSongs` 和 `refreshFolderPlaylistById` 的路径差异计算逻辑
- `_buildPathMap` 参数类型优化为 `Iterable<String>`，消除冗余 `.toList()` 转换

### 其他

- 为目录遍历添加错误处理（`.handleError`），避免扫描时因权限问题崩溃
- 将生成的插件注册文件加入 `.gitignore`
- 在 Windows 平台 CMake 配置中添加 `/wd"4819"` 禁用 C4819 警告（mpv_audio_kit 插件中的 UTF-8 文件在 GBK 代码页下产生此警告，`/WX` 将其视为错误）