### PR TITLE
feat: 专辑/歌手列表从详情页返回时恢复滚动位置

### DIFF
--- a/lib/page/song_list/album_list.dart
+++ b/lib/page/song_list/album_list.dart
@@ -17,6 +17,8 @@ class AlbumList extends StatefulWidget {
 
 class _AlbumListState extends State<AlbumList> {
   late final ScrollController _scrollController = ScrollController();
+  double _savedScrollOffset = 0.0;
+  bool _prevShowAlbumDetail = false;
 
   @override
   void dispose() {
@@ -58,6 +60,25 @@ class _AlbumListState extends State<AlbumList> {
       final pb = getPy(b);
       return pa.compareTo(pb);
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final notifier = context.read<PlaylistContentNotifier>();
+    final showAlbumDetail =
+        notifier.currentDetailViewContext == DetailViewContext.album;
+
+    if (!showAlbumDetail && _prevShowAlbumDetail && _savedScrollOffset > 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (_scrollController.hasClients) {
+          _scrollController.jumpTo(_savedScrollOffset);
+          _savedScrollOffset = 0.0;
+        }
+      });
+    }
+    _prevShowAlbumDetail = showAlbumDetail;
   }
 
   @override
@@ -225,6 +246,10 @@ class _AlbumListState extends State<AlbumList> {
 
                                 return InkWell(
                                   onTap: () {
+                                    if (_scrollController.hasClients) {
+                                      _savedScrollOffset =
+                                          _scrollController.offset;
+                                    }
                                     notifier.setActiveAlbumView(albumName);
                                   },
                                   borderRadius: BorderRadius.circular(12.0),

--- a/lib/page/song_list/artist_list.dart
+++ b/lib/page/song_list/artist_list.dart
@@ -17,6 +17,9 @@ class ArtistList extends StatefulWidget {
 
 class _ArtistListState extends State<ArtistList> {
   late final ScrollController _scrollController = ScrollController();
+  double _savedScrollOffset = 0.0;
+  bool _prevShowArtistDetail = false;
+
   @override
   void dispose() {
     _scrollController.dispose();
@@ -57,6 +60,25 @@ class _ArtistListState extends State<ArtistList> {
       final pb = getPy(b);
       return pa.compareTo(pb);
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final notifier = context.read<PlaylistContentNotifier>();
+    final showArtistDetail =
+        notifier.currentDetailViewContext == DetailViewContext.artist;
+
+    if (!showArtistDetail && _prevShowArtistDetail && _savedScrollOffset > 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (_scrollController.hasClients) {
+          _scrollController.jumpTo(_savedScrollOffset);
+          _savedScrollOffset = 0.0;
+        }
+      });
+    }
+    _prevShowArtistDetail = showArtistDetail;
   }
 
   @override
@@ -220,6 +242,10 @@ class _ArtistListState extends State<ArtistList> {
                                   title: Text(artistName),
                                   subtitle: Text('共 ${songs.length} 首歌曲'),
                                   onTap: () {
+                                    if (_scrollController.hasClients) {
+                                      _savedScrollOffset =
+                                          _scrollController.offset;
+                                    }
                                     notifier.setActiveArtistView(artistName);
                                   },
                                   shape: RoundedRectangleBorder(


### PR DESCRIPTION
#### 背景
在专辑列表和歌手列表中，用户点击某条目进入详情页后返回时，列表会回到顶部，需要重新滚动查找之前的位置。