### PR TITLE
refactor(playlist&album): 优化封面加载与路径处理

### DIFF
--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -992,9 +992,13 @@ class PlaylistContentNotifier extends ChangeNotifier {
 
     void updateList(List<Song> songs) {
       for (int i = 0; i < songs.length; i++) {
-        if (_normalizePath(songs[i].filePath) == targetPath) {
-          songs[i] = updater(songs[i]);
-          updated = true;
+        if (songs[i].normalizedPath == targetPath) {
+          final newSong = updater(songs[i]);
+          // updater 返回同一对象表示无变更，跳过以避免冗余刷新
+          if (!identical(newSong, songs[i])) {
+            songs[i] = newSong;
+            updated = true;
+          }
         }
       }
     }
@@ -1021,9 +1025,13 @@ class PlaylistContentNotifier extends ChangeNotifier {
 
     // 单独处理当前播放歌曲
     if (_currentSong != null &&
-        _normalizePath(_currentSong!.filePath) == targetPath) {
-      _currentSong = updater(_currentSong!);
-      updated = true;
+        _currentSong!.normalizedPath == targetPath) {
+      final newSong = updater(_currentSong!);
+      // 无变更时跳过
+      if (!identical(newSong, _currentSong)) {
+        _currentSong = newSong;
+        updated = true;
+      }
     }
 
     if (updated) {
@@ -1130,14 +1138,17 @@ class PlaylistContentNotifier extends ChangeNotifier {
 
     // 缓存命中：直接应用，无需磁盘读取
     if (_coverCache.containsKey(cacheKey)) {
-      _applyCachedCover(cacheKey);
+      // 延迟到微任务执行，避免在 build 阶段触发 notifyListeners
+      scheduleMicrotask(() => _applyCachedCover(cacheKey));
       return;
     }
 
-    // 歌曲对象上已有封面数据
+    // 歌曲对象上已有封面数据：缓存并传播到同路径的其他歌曲
     final song = _findSongByPath(filePath);
-    if (song?.albumArt != null) {
-      _coverCache[cacheKey] = song!.albumArt;
+    final albumArt = song?.albumArt;
+    if (albumArt != null && albumArt.isNotEmpty) {
+      _coverCache[cacheKey] = albumArt;
+      scheduleMicrotask(() => _applyCachedCover(cacheKey));
       return;
     }
 
@@ -1158,7 +1169,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
     _removeFromCoverQueue(cacheKey);
 
     if (_currentSong != null &&
-        _normalizePath(_currentSong!.filePath) == cacheKey) {
+        _currentSong!.normalizedPath == cacheKey) {
       return;
     }
 
@@ -1172,25 +1183,25 @@ class PlaylistContentNotifier extends ChangeNotifier {
     final target = _normalizePath(filePath);
     if (_isUsingQueue && _currentPlayingQueue != null) {
       for (final song in _currentPlayingQueue!) {
-        if (_normalizePath(song.filePath) == target) {
+        if (song.normalizedPath == target) {
           return song;
         }
       }
     }
     if (_playingPlaylist?.songs != null) {
       for (final song in _playingPlaylist!.songs!) {
-        if (_normalizePath(song.filePath) == target) {
+        if (song.normalizedPath == target) {
           return song;
         }
       }
     }
     for (final song in _currentPlaylistSongs) {
-      if (_normalizePath(song.filePath) == target) {
+      if (song.normalizedPath == target) {
         return song;
       }
     }
     for (final song in _allSongs) {
-      if (_normalizePath(song.filePath) == target) {
+      if (song.normalizedPath == target) {
         return song;
       }
     }
@@ -1214,10 +1225,9 @@ class PlaylistContentNotifier extends ChangeNotifier {
   void _applyCachedCover(String cacheKey) {
     final cachedCover = _coverCache[cacheKey];
     if (cachedCover == null) return;
-    final song = _findSongByPath(cacheKey);
-    if (song?.albumArt == cachedCover) return;
 
     _updateSongInCollections(cacheKey, (song) {
+      if (song.albumArt == cachedCover) return song;
       return Song(
         title: song.title,
         artist: song.artist,
@@ -1301,7 +1311,8 @@ class PlaylistContentNotifier extends ChangeNotifier {
           });
         }
       } catch (e) {
-        //
+        // 记录失败原因，排查封面加载问题
+        debugPrint('加载封面失败: ${p.basename(filePath)} - $e');
       } finally {
         _pendingCoverRequests.remove(cacheKey);
       }
@@ -2055,7 +2066,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
   Future<void> stop() async {
     await _audioService.player.stop();
     if (_currentSong != null) {
-      final oldPath = _normalizePath(_currentSong!.filePath);
+      final oldPath = _currentSong!.normalizedPath;
       _currentSong = null;
       if (!_visibleCoverPaths.contains(oldPath)) {
         _evictableCoverPaths.add(oldPath);
@@ -2597,10 +2608,8 @@ class PlaylistContentNotifier extends ChangeNotifier {
     }
 
     // 切换播放歌曲时管理封面缓存
-    final oldSongPath = _currentSong != null
-        ? _normalizePath(_currentSong!.filePath)
-        : null;
-    final newSongPath = _normalizePath(songFilePath);
+    final oldSongPath = _currentSong?.normalizedPath;
+    final newSongPath = songToPlay.normalizedPath;
 
     _currentSong = songToPlay;
     _evictableCoverPaths.remove(newSongPath);
@@ -2854,7 +2863,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
             _playingPlaylist = null;
             _playingSongIndex = -1;
             if (_currentSong != null) {
-              final oldPath = _normalizePath(_currentSong!.filePath);
+              final oldPath = _currentSong!.normalizedPath;
               _currentSong = null;
               if (!_visibleCoverPaths.contains(oldPath)) {
                 _evictableCoverPaths.add(oldPath);
@@ -2872,7 +2881,7 @@ class PlaylistContentNotifier extends ChangeNotifier {
           _playingPlaylist = null;
           _playingSongIndex = -1;
           if (_currentSong != null) {
-            final oldPath = _normalizePath(_currentSong!.filePath);
+            final oldPath = _currentSong!.normalizedPath;
             _currentSong = null;
             if (!_visibleCoverPaths.contains(oldPath)) {
               _evictableCoverPaths.add(oldPath);

--- a/lib/page/playlist/playlist_content_widget.dart
+++ b/lib/page/playlist/playlist_content_widget.dart
@@ -1888,7 +1888,9 @@ class _SongTileWidgetState extends State<SongTileWidget> {
                 leading: SizedBox(
                   width: 50,
                   height: 50,
-                  child: widget.song.albumArt != null
+                  // isNotEmpty: 过滤空字节数组；errorBuilder: 兜底解码失败
+                  child: widget.song.albumArt != null &&
+                          widget.song.albumArt!.isNotEmpty
                       ? ClipRRect(
                           borderRadius: BorderRadius.circular(6),
                           child: Image.memory(
@@ -1896,6 +1898,13 @@ class _SongTileWidgetState extends State<SongTileWidget> {
                             widget.song.albumArt!,
                             fit: BoxFit.cover,
                             gaplessPlayback: true,
+                            errorBuilder: (context, error, stackTrace) {
+                              return const Icon(
+                                Icons.music_note,
+                                size: 40,
+                                color: Colors.grey,
+                              );
+                            },
                           ),
                         )
                       : const Icon(

--- a/lib/page/playlist/playlist_models.dart
+++ b/lib/page/playlist/playlist_models.dart
@@ -1,11 +1,13 @@
 import 'package:uuid/uuid.dart';
 import 'dart:typed_data';
+import 'package:path/path.dart' as p;
 
 class Song {
   final String title;
   final String artist;
   final String album;
   final String filePath;
+  final String normalizedPath; // 缓存归一化路径，避免热路径上重复调用 p.normalize
   final Uint8List? albumArt;
   final Duration? duration;
   final int? trackNumber;
@@ -18,7 +20,7 @@ class Song {
     this.albumArt,
     this.duration,
     this.trackNumber,
-  });
+  }) : normalizedPath = p.normalize(filePath);
 
   Map<String, dynamic> toJson() {
     return {'title': title, 'artist': artist, 'filePath': filePath};

--- a/lib/page/song_list/album_detail_view.dart
+++ b/lib/page/song_list/album_detail_view.dart
@@ -352,7 +352,13 @@ class _AlbumHeaderBackdrop extends StatelessWidget {
     return Stack(
       fit: StackFit.expand,
       children: [
-        Image.memory(cover!, fit: BoxFit.cover, gaplessPlayback: true),
+        Image.memory(
+          cover!,
+          fit: BoxFit.cover,
+          gaplessPlayback: true,
+          cacheWidth: 600,
+          errorBuilder: (context, error, stackTrace) => const SizedBox.shrink(),
+        ),// 缓存封面
         BackdropFilter(
           filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
           child: ColoredBox(color: baseColor.withValues(alpha: 0.40)),

--- a/lib/page/song_list/album_list.dart
+++ b/lib/page/song_list/album_list.dart
@@ -371,12 +371,16 @@ class _AlbumCoverTileState extends State<_AlbumCoverTile> {
     return Container(
       width: double.infinity,
       color: Theme.of(context).colorScheme.secondaryContainer,
-      child: widget.albumArt != null
+      // isNotEmpty: 过滤空字节数组；errorBuilder: 兜底解码失败
+      child: widget.albumArt != null && widget.albumArt!.isNotEmpty
           ? Image.memory(
               cacheWidth: 200,
               widget.albumArt!,
               fit: BoxFit.cover,
               gaplessPlayback: true,
+              errorBuilder: (context, error, stackTrace) {
+                return const Icon(Icons.album, size: 50);
+              },
             )
           : const Icon(Icons.album, size: 50),
     );


### PR DESCRIPTION
### 概述

本 PR 对播放列表与专辑封面的加载逻辑进行重构与优化，主要解决四类问题：
1. **性能**：路径归一化在热路径上重复计算，滚动大库时产生大量字符串分配
2. **正确性**：`_applyCachedCover` 仅检查首个匹配歌曲，导致同路径其他歌曲封面遗漏；空字节数组未过滤
3. **健壮性**：`Image.memory` 缺少解码失败兜底；封面加载异常被静默吞掉
4. **安全性**：`requestSongCover` 在 build 阶段同步触发 `notifyListeners()`，可能导致 Flutter 断言错误

### 变更明细

#### 1. 路径归一化缓存（`playlist_models.dart`）
- 新增 `Song.normalizedPath` 字段，在构造函数中一次性计算 `p.normalize(filePath)`
- 热路径（`_findSongByPath`、`_updateSongInCollections`、`stop`、`_startPlaybackNow` 等）由 `_normalizePath(song.filePath)` 改为直接读取 `song.normalizedPath`
- `_startPlaybackNow` 中 `newSongPath` 也改用 `songToPlay.normalizedPath`，消除最后一次冗余归一化
- **收益**：滚动时每个可见 tile 触发的封面查找，从 O(n) 次字符串分配降为 O(n) 次字符串比较

#### 2. 列表更新去冗余（`playlist_content_notifier.dart`）
- `_updateSongInCollections` 内增加 `identical()` 检查：updater 返回同一对象时跳过赋值与 `notifyListeners()`
- 配合 `_applyCachedCover` 内的 `if (song.albumArt == cachedCover) return song;`，避免无意义对象重建

#### 3. 封面传播修复（`playlist_content_notifier.dart`）
- **旧逻辑**：`_applyCachedCover` 通过 `_findSongByPath` 找到首个歌曲后，若其 `albumArt == cachedCover` 即整体 return，导致**其他同路径但缺封面的歌曲不会被更新**
- **新逻辑**：移除外部提前 return，将检查下沉到 updater 内部，逐歌曲判断是否需要应用封面
- `requestSongCover` 中，当歌曲自带封面时新增 `_applyCachedCover(cacheKey)` 调用，主动传播到同路径其他歌曲，避免重复磁盘读取

#### 4. build 阶段安全（`playlist_content_notifier.dart`）
- `requestSongCover` 中的 `_applyCachedCover` 调用（缓存命中路径 + 歌曲已有封面路径）改为 `scheduleMicrotask` 延迟执行
- **原因**：`SongTileWidget.didUpdateWidget` 在 build 阶段直接调用 `requestSongCover`，同步 `notifyListeners()` 会触发 Flutter 断言错误
- 微任务在当前事件循环末尾、下一帧渲染前执行，用户不会感知延迟

#### 5. 空数据与解码失败兜底（`playlist_content_widget.dart`、`album_list.dart`、`album_detail_view.dart`）
- `albumArt` 判断由 `!= null` 增强为 `!= null && isNotEmpty`，过滤空字节数组
- `Image.memory` 新增 `errorBuilder`，解码失败时显示占位图标（歌曲/专辑 tile）或透明（背景层），避免 UI 异常

#### 6. 其他
- 封面加载 `catch` 块由静默 `//` 改为 `debugPrint`，输出文件名与异常信息便于排查

### 涉及文件

| 文件 | 变更 |
|------|------|
| `lib/page/playlist/playlist_models.dart` | 新增 `normalizedPath` 字段 |
| `lib/page/playlist/playlist_content_notifier.dart` | 路径缓存、更新去冗余、封面传播修复、scheduleMicrotask、日志 |
| `lib/page/playlist/playlist_content_widget.dart` | 空数据过滤 + 解码兜底 |
| `lib/page/song_list/album_detail_view.dart` | 背景图 cacheWidth + errorBuilder |
| `lib/page/song_list/album_list.dart` | 空数据过滤 + 解码兜底 |