### PR TITLE
fix: 将专辑/歌手筛选状态迁移到 PlaylistContentNotifier

### DIFF
--- a/lib/page/playlist/playlist_content_notifier.dart
+++ b/lib/page/playlist/playlist_content_notifier.dart
@@ -286,6 +286,22 @@ class PlaylistContentNotifier extends ChangeNotifier {
   String get activeDetailTitle => _activeDetailTitle;
   List<Song> get activeSongList => _activeSongList;
 
+  // --- 专辑/歌手筛选状态（保存在 Notifier 中）---
+  bool _hideSingleSongAlbums = false;
+  bool _hideSingleSongArtists = false;
+  bool get hideSingleSongAlbums => _hideSingleSongAlbums;
+  bool get hideSingleSongArtists => _hideSingleSongArtists;
+
+  void toggleHideSingleSongAlbums() {
+    _hideSingleSongAlbums = !_hideSingleSongAlbums;
+    notifyListeners();
+  }
+
+  void toggleHideSingleSongArtists() {
+    _hideSingleSongArtists = !_hideSingleSongArtists;
+    notifyListeners();
+  }
+
   // --- 存储从JSON加载的排序信息 ---
   Map<String, List<String>> _artistSortOrders = {};
   Map<String, List<String>> _albumSortOrders = {};

--- a/lib/page/song_list/album_list.dart
+++ b/lib/page/song_list/album_list.dart
@@ -29,7 +29,6 @@ class _AlbumListState extends State<AlbumList> {
 
   bool _isSearching = false;
   String _searchKeyword = '';
-  bool _hideSingleSongAlbums = false;
 
   void _closeAlbumDetail() {
     final notifier = context.read<PlaylistContentNotifier>();
@@ -159,20 +158,18 @@ class _AlbumListState extends State<AlbumList> {
                               const Spacer(),
                               IconButton(
                                 icon: Icon(
-                                  _hideSingleSongAlbums
+                                  notifier.hideSingleSongAlbums
                                       ? Icons.filter_alt_off_outlined
                                       : Icons.filter_alt_outlined,
-                                  color: _hideSingleSongAlbums
+                                  color: notifier.hideSingleSongAlbums
                                       ? Theme.of(context).colorScheme.primary
                                       : null,
                                 ),
-                                tooltip: _hideSingleSongAlbums
+                                tooltip: notifier.hideSingleSongAlbums
                                     ? '显示所有专辑'
                                     : '隐藏只有单首歌曲的专辑',
-                                onPressed: () => setState(() {
-                                  _hideSingleSongAlbums =
-                                      !_hideSingleSongAlbums;
-                                }),
+                                onPressed: () =>
+                                    notifier.toggleHideSingleSongAlbums(),
                               ),
                               IconButton(
                                 icon: const Icon(Icons.search),
@@ -205,7 +202,7 @@ class _AlbumListState extends State<AlbumList> {
                           }
 
                           // 应用单曲专辑过滤逻辑
-                          if (_hideSingleSongAlbums) {
+                          if (notifier.hideSingleSongAlbums) {
                             albumNames = albumNames.where((name) {
                               return albums[name]!.length > 1;
                             }).toList();

--- a/lib/page/song_list/artist_list.dart
+++ b/lib/page/song_list/artist_list.dart
@@ -29,7 +29,6 @@ class _ArtistListState extends State<ArtistList> {
 
   bool _isSearching = false;
   String _searchKeyword = '';
-  bool _hideSingleSongArtists = false;
 
   void _closeArtistDetail() {
     final notifier = context.read<PlaylistContentNotifier>();
@@ -159,20 +158,18 @@ class _ArtistListState extends State<ArtistList> {
                               const Spacer(),
                               IconButton(
                                 icon: Icon(
-                                  _hideSingleSongArtists
+                                  notifier.hideSingleSongArtists
                                       ? Icons.filter_alt_off_outlined
                                       : Icons.filter_alt_outlined,
-                                  color: _hideSingleSongArtists
+                                  color: notifier.hideSingleSongArtists
                                       ? Theme.of(context).colorScheme.primary
                                       : null,
                                 ),
-                                tooltip: _hideSingleSongArtists
+                                tooltip: notifier.hideSingleSongArtists
                                     ? '显示所有歌手'
                                     : '隐藏只有单首歌曲的歌手',
-                                onPressed: () => setState(() {
-                                  _hideSingleSongArtists =
-                                      !_hideSingleSongArtists;
-                                }),
+                                onPressed: () =>
+                                    notifier.toggleHideSingleSongArtists(),
                               ),
                               IconButton(
                                 icon: const Icon(Icons.search),
@@ -204,7 +201,7 @@ class _ArtistListState extends State<ArtistList> {
                           }
 
                           // 应用单曲歌手过滤逻辑
-                          if (_hideSingleSongArtists) {
+                          if (notifier.hideSingleSongArtists) {
                             artistNames = artistNames.where((name) {
                               return artists[name]!.length > 1;
                             }).toList();


### PR DESCRIPTION

**问题：**
`_AlbumListState._hideSingleSongAlbums` 和 `_ArtistListState._hideSingleSongArtists` 存储在页面 `State` 中。主导航通过 `pushNamedAndRemoveUntil(..., false)` 切换页面时原路由被销毁，`State` 随之释放，返回时筛选值恢复为默认值 `false`。

**修改：**
- `PlaylistContentNotifier` — 新增 `_hideSingleSongAlbums` / `_hideSingleSongArtists` 字段、getter 及 `toggleHideSingleSongAlbums()` / `toggleHideSingleSongArtists()` 方法，状态保存在长生命周期的 Notifier 中
- `album_list.dart` — 移除本地 `_hideSingleSongAlbums`，改用 `notifier.hideSingleSongAlbums` 读取、`notifier.toggleHideSingleSongAlbums` 切换
- `artist_list.dart` — 同上，对应 `_hideSingleSongArtists`

**备注：** 如需持久化到磁盘可后续另行处理。